### PR TITLE
Add support for IPv6

### DIFF
--- a/lib/vagrant-scaleway/action/create_server.rb
+++ b/lib/vagrant-scaleway/action/create_server.rb
@@ -22,6 +22,7 @@ module VagrantPlugins
           bootscript      = config.bootscript
           commercial_type = config.commercial_type
           image           = config.image
+          enable_ipv6     = config.enable_ipv6
           name            = config.name
           security_group  = config.security_group
           tags            = config.tags
@@ -31,6 +32,7 @@ module VagrantPlugins
           env[:ui].info(" -- Bootscript: #{bootscript}") if bootscript
           env[:ui].info(" -- Commercial Type: #{commercial_type}")
           env[:ui].info(" -- Image: #{image}")
+          env[:ui].info(" -- IPv6 enabled: #{enable_ipv6}")
           env[:ui].info(" -- Name: #{name}")
           env[:ui].info(" -- Security Group: #{security_group}") if security_group
           env[:ui].info(" -- Tags: #{tags}") unless tags.empty?
@@ -41,6 +43,7 @@ module VagrantPlugins
             image:           image,
             volumes:         volumes,
             commercial_type: commercial_type,
+            enable_ipv6: enable_ipv6,
             tags:            tags
           }
 

--- a/lib/vagrant-scaleway/config.rb
+++ b/lib/vagrant-scaleway/config.rb
@@ -17,6 +17,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :image
 
+      # The image ID.
+      #
+      # @return [String]
+      attr_accessor :enable_ipv6
+
       # The name of the server.
       #
       # @return [String]
@@ -83,6 +88,7 @@ module VagrantPlugins
         @bootscript            = UNSET_VALUE
         @commercial_type       = UNSET_VALUE
         @image                 = UNSET_VALUE
+        @enable_ipv6           = UNSET_VALUE
         @name                  = UNSET_VALUE
         @organization          = UNSET_VALUE
         @region                = UNSET_VALUE
@@ -99,6 +105,7 @@ module VagrantPlugins
         @bootscript      = nil if @bootscript == UNSET_VALUE
         @commercial_type = 'C2S' if @commercial_type == UNSET_VALUE
         @image           = '75c28f52-6c64-40fc-bb31-f53ca9d02de9' if @image == UNSET_VALUE
+        @enable_ipv6     = true if @enable_ipv6 == UNSET_VALUE
 
         if @name == UNSET_VALUE
           require 'securerandom'


### PR DESCRIPTION
And enable it by default, since all Scaleway compute instances now support IPv6.

Fix https://github.com/kaorimatz/vagrant-scaleway/issues/12