### PR TITLE
Add .vagrant to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/.vagrant/
 /.yardoc
 /Gemfile.lock
 /_yardoc/


### PR DESCRIPTION
I noticed files were written to this folder when running `bundle exec vagrant...`