### PR TITLE
fix(destroy): fix exception rescue

### DIFF
--- a/lib/vagrant-scaleway/action/destroy_server.rb
+++ b/lib/vagrant-scaleway/action/destroy_server.rb
@@ -16,7 +16,7 @@ module VagrantPlugins
           begin
             server.destroy
           rescue Fog::Scaleway::Compute::InvalidRequestError => e
-            if e.message =~ /server should be stopped/
+            if e.message =~ /instance should be powered off/
               server.terminate(false)
             else
               raise


### PR DESCRIPTION
The message changed, so the regex needed to be updated in order for "destroy" to work when the instance is still running.

Fix https://github.com/kaorimatz/vagrant-scaleway/issues/10

```
  :body          => "{\"type\": \"invalid_request_error\", \"message\": \"instance should be powered off\"}"
  :cookies       => [
  ]
  :headers       => {
    "content-length"            => "78"
    "content-security-policy"   => "default-src 'none'; frame-ancestors 'none'"
    "content-type"              => "application/json"
    "date"                      => "Sun, 04 Oct 2020 11:29:41 GMT"
    "server"                    => "Scaleway API-Gateway"
    "strict-transport-security" => "max-age=63072000"
    "warning"                   => "299 - \"Deprecated API please use https://api.scaleway.com/instance/v1/zones/fr-par-1/\""
    "x-content-type-options"    => "nosniff"
    "x-frame-options"           => "DENY"
    "x-request-id"              => "cb6fa384-42a8-4b88-ab88-9380ddfe3871"
  }
  :host          => "cp-PAR1.scaleway.com"
  :local_address => "10.66.66.2"
  :local_port    => 64718
  :path          => "/servers/66a8dc7c-cc1e-4c7c-8b6e-6f29793aba7b"
  :port          => 443
  :reason_phrase => "Bad Request"
  :remote_ip     => "51.159.69.134"
  :status        => 400
  :status_line   => "HTTP/1.1 400 Bad Request\r\n"
```