### PR TITLE
fix(destroy,halt): remove tasks status polling

### DIFF
--- a/lib/vagrant-scaleway/action/destroy_server.rb
+++ b/lib/vagrant-scaleway/action/destroy_server.rb
@@ -17,7 +17,7 @@ module VagrantPlugins
             server.destroy
           rescue Fog::Scaleway::Compute::InvalidRequestError => e
             if e.message =~ /server should be stopped/
-              server.terminate(false)
+              server.terminate(true)
             else
               raise
             end

--- a/lib/vagrant-scaleway/action/stop_server.rb
+++ b/lib/vagrant-scaleway/action/stop_server.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
             env[:ui].info(I18n.t('vagrant_scaleway.already_status', status: env[:machine].state.id))
           else
             env[:ui].info(I18n.t('vagrant_scaleway.stopping'))
-            server.poweroff(false)
+            server.poweroff(true)
           end
 
           @app.call(env)


### PR DESCRIPTION
Since the tasks API endpoint does not exist anymore (https://github.com/kaorimatz/fog-scaleway/issues/7), polling for the task will result in an error even if the actual task succeeded.

While tasks-related code should be removed from fog-scaleway, setting `async` to true for the `server.terminate` and `server.poweroff` methods will bypass this polling.

Closes https://github.com/kaorimatz/vagrant-scaleway/issues/9. Fixes `destroy` with https://github.com/kaorimatz/vagrant-scaleway/pull/11.